### PR TITLE
Fix lifecycle manager key in nav2 params

### DIFF
--- a/src/ackermann_robot_navigation/params/nav2_params.yaml
+++ b/src/ackermann_robot_navigation/params/nav2_params.yaml
@@ -74,7 +74,7 @@ map_server:
     use_sim_time: True
     yaml_filename: "blank_map.yaml"   # replace with actual map if you have one
 
-lifecyle_manager:
+lifecycle_manager:
   ros__parameters:
     use_sim_time: True
     autostart: True


### PR DESCRIPTION
## Summary
- rename the nav2 param key `lifecyle_manager` to `lifecycle_manager`

## Testing
- `pytest -q` *(fails: ImportError for `ament_copyright`)*

------
https://chatgpt.com/codex/tasks/task_e_685073c754288325a182d23589836e07