### PR TITLE
Launch joint state publishers

### DIFF
--- a/src/ackermann_control_bridge/package.xml
+++ b/src/ackermann_control_bridge/package.xml
@@ -10,6 +10,7 @@
   <depend>rclpy</depend>
   <depend>geometry_msgs</depend>
   <depend>std_msgs</depend>
+  <exec_depend>robot_state_publisher</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/src/ackermann_robot_description/launch/bringup_all.launch.py
+++ b/src/ackermann_robot_description/launch/bringup_all.launch.py
@@ -30,6 +30,18 @@ def generate_launch_description():
                 output='screen'
             ),
             Node(
+                package='joint_state_publisher',
+                executable='joint_state_publisher',
+                name='joint_state_publisher',
+                output='screen'
+            ),
+            Node(
+                package='joint_state_publisher_gui',
+                executable='joint_state_publisher_gui',
+                name='joint_state_publisher_gui',
+                output='screen'
+            ),
+            Node(
                 package='robot_state_publisher',
                 executable='robot_state_publisher',
                 name='robot_state_publisher',

--- a/src/ackermann_robot_description/launch/spawn_ackermann.launch.py
+++ b/src/ackermann_robot_description/launch/spawn_ackermann.launch.py
@@ -21,6 +21,20 @@ def generate_launch_description():
             output='screen'
         ),
 
+        # Publish joint states from the URDF
+        Node(
+            package='joint_state_publisher',
+            executable='joint_state_publisher',
+            name='joint_state_publisher',
+            output='screen'
+        ),
+        Node(
+            package='joint_state_publisher_gui',
+            executable='joint_state_publisher_gui',
+            name='joint_state_publisher_gui',
+            output='screen'
+        ),
+
         # Robot State Publisher (to publish TF from urdf)
         Node(
             package='robot_state_publisher',

--- a/src/ackermann_robot_description/package.xml
+++ b/src/ackermann_robot_description/package.xml
@@ -20,6 +20,9 @@
   <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>gazebo_ros2_control</exec_depend>
   <exec_depend>pluginlib</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/ackermann_robot_navigation/launch/bringup_all.launch.py
+++ b/src/ackermann_robot_navigation/launch/bringup_all.launch.py
@@ -31,6 +31,18 @@ def generate_launch_description():
                 output='screen'
             ),
             Node(
+                package='joint_state_publisher',
+                executable='joint_state_publisher',
+                name='joint_state_publisher',
+                output='screen'
+            ),
+            Node(
+                package='joint_state_publisher_gui',
+                executable='joint_state_publisher_gui',
+                name='joint_state_publisher_gui',
+                output='screen'
+            ),
+            Node(
                 package='robot_state_publisher',
                 executable='robot_state_publisher',
                 name='robot_state_publisher',

--- a/src/ackermann_robot_navigation/package.xml
+++ b/src/ackermann_robot_navigation/package.xml
@@ -22,6 +22,9 @@
   <depend>nav2_util</depend>
   <depend>rclcpp</depend>
   <depend>nav2_msgs</depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Summary
- publish joint states when launching in Gazebo
- declare joint_state_publisher and GUI runtime dependencies
- declare robot_state_publisher runtime dependency in all packages

## Testing
- `colcon test --packages-select ackermann_control_bridge` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685137b5e8b48325838580d783aee050