### PR TITLE
Add lidar and depth camera sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains a minimal setup for an Ackermann drive robot using the 
 - `src/ackermann_robot_description` – URDF model and Gazebo launch files for the robot
 - `src/ackermann_control_bridge` – node that converts `/cmd_vel` into steering and wheel commands
 - `src/ackermann_robot_navigation` – navigation configuration and launch files
+- The robot description now includes a 2D LIDAR publishing `/scan` and a depth camera publishing `/depth/image_raw` in Gazebo.
 
 ## How the nav2 Stack Works
 The nav2 stack is a collection of ROS 2 nodes that provide navigation capabilities:
@@ -39,3 +40,4 @@ colcon build --symlink-install
 
 The robot will read the map in `src/ackermann_robot_navigation/maps/blank_map.yaml` and you can send goals using RViz2 or the `/navigate_to_pose` action.
 
+The LiDAR and depth camera data is available on `/scan` and `/depth/image_raw`.

--- a/src/ackermann_robot_description/urdf/ackermann_robot.urdf.xacro
+++ b/src/ackermann_robot_description/urdf/ackermann_robot.urdf.xacro
@@ -190,6 +190,102 @@
     </plugin>
   </gazebo>
 
+  <!--**********************-->
+  <!-- Sensors -->
+  <!--**********************-->
+  <link name="lidar_link">
+    <visual>
+      <geometry>
+        <cylinder length="0.02" radius="0.04"/>
+      </geometry>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+    </visual>
+    <collision>
+      <geometry>
+        <cylinder length="0.02" radius="0.04"/>
+      </geometry>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+    </collision>
+    <inertial>
+      <mass value="0.1"/>
+      <inertia ixx="0.001" ixy="0.0" ixz="0.0" iyy="0.001" iyz="0.0" izz="0.001"/>
+    </inertial>
+  </link>
+  <joint name="lidar_joint" type="fixed">
+    <parent link="base_chassis"/>
+    <child link="lidar_link"/>
+    <origin xyz="0 0 ${chassis_height + 0.05}" rpy="0 0 0"/>
+  </joint>
+  <gazebo reference="lidar_link">
+    <sensor name="lidar" type="ray">
+      <pose>0 0 0 0 0 0</pose>
+      <update_rate>10</update_rate>
+      <ray>
+        <scan>
+          <horizontal>
+            <samples>720</samples>
+            <min_angle>-1.5708</min_angle>
+            <max_angle>1.5708</max_angle>
+          </horizontal>
+        </scan>
+        <range>
+          <min>0.1</min>
+          <max>10.0</max>
+          <resolution>0.01</resolution>
+        </range>
+      </ray>
+      <plugin name="gazebo_ros_laser" filename="libgazebo_ros_ray_sensor.so">
+        <topicName>scan</topicName>
+        <frameName>lidar_link</frameName>
+      </plugin>
+    </sensor>
+  </gazebo>
+
+  <link name="depth_camera_link">
+    <visual>
+      <geometry>
+        <box size="0.05 0.05 0.05"/>
+      </geometry>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+    </visual>
+    <collision>
+      <geometry>
+        <box size="0.05 0.05 0.05"/>
+      </geometry>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+    </collision>
+    <inertial>
+      <mass value="0.2"/>
+      <inertia ixx="0.002" ixy="0.0" ixz="0.0" iyy="0.002" iyz="0.0" izz="0.002"/>
+    </inertial>
+  </link>
+  <joint name="depth_camera_joint" type="fixed">
+    <parent link="base_chassis"/>
+    <child link="depth_camera_link"/>
+    <origin xyz="0 0 ${chassis_height + 0.1}" rpy="0 0 0"/>
+  </joint>
+  <gazebo reference="depth_camera_link">
+    <sensor name="depth_camera" type="depth">
+      <pose>0 0 0 0 0 0</pose>
+      <update_rate>30</update_rate>
+      <camera>
+        <horizontal_fov>1.047</horizontal_fov>
+        <image>
+          <width>640</width>
+          <height>480</height>
+          <format>R8G8B8</format>
+        </image>
+        <clip>
+          <near>0.05</near>
+          <far>10.0</far>
+        </clip>
+      </camera>
+      <plugin name="gazebo_ros_depth_camera" filename="libgazebo_ros_depth_camera.so">
+        <topicName>depth/image_raw</topicName>
+        <frameName>depth_camera_link</frameName>
+      </plugin>
+    </sensor>
+  </gazebo>
 
 </robot>
 


### PR DESCRIPTION
## Summary
- add 2D lidar publishing on `/scan`
- add depth camera publishing on `/depth/image_raw`
- document new sensors in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `ament_*` modules)*

------
https://chatgpt.com/codex/tasks/task_e_68513ee705e483259f065e351b5e0d8e